### PR TITLE
Update GDN documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 To better support Go user groups worldwide, [GoBridge](https://gobridge.org/) and Google have joined forces to create a new program called the Go Developer Network (GDN). The GDN is a collection of Go user groups working together with a shared mission to empower developer communities with the knowledge, experience, and wisdom to build the next generation of software in Go. This network creates a single place for people to search for local user groups, events, and see what other Gophers are doing around the world.
 
-* [GDN Artwork](./logo)
-* [GDN Special Event Templates](./events)
+* [GDN Program Charter](./program_charter.md)
+* [GDN Event Templates](./events)
+* [GDN Public Artwork](./logo)
 
 ### Submit a Request
 

--- a/README.md
+++ b/README.md
@@ -2,40 +2,58 @@
 
 To better support Go user groups worldwide, [GoBridge](https://gobridge.org/) and Google have joined forces to create a new program called the Go Developer Network (GDN). The GDN is a collection of Go user groups working together with a shared mission to empower developer communities with the knowledge, experience, and wisdom to build the next generation of software in Go. This network creates a single place for people to search for local user groups, events, and see what other Gophers are doing around the world.
 
+* [GDN Artwork](./logo)
+* [GDN Special Event Templates](./events)
+
+### Submit a Request
+
+ If you are a member or an organizer of a Go meetup group within the GDN looking for assistance, please feel free to open a [New Issue](ht  tps://github.com/gobridge/gdn/issues/new/choose). Issues are publicly visible. To reach out privately,  please send GoBridge an email at gdn@gobridge.org.
+
 ### How to Join
 
 If you currently run a Go developer group on meetup.com or you want to start a new Go developer group on meetup.com, please send GoBridge an email at gdn@gobridge.org. If you are a Go developer looking for a meetup to join, find a meetup near you on the [GDN map](https://meetup.com/pro/go).
 
+Refer to [GDN membership requirements](#user-content-membership-requirements) for joining the GDN.
+
 ### FAQ
 
-**Who is GoBridge (GB) and what is their role in the Go community?**  
+**Who is GoBridge (GB) and what is their role in the Go community?**
+
 In July of 2015, GoBridge was formed with the mission to increase diversity in the Go community by teaching workshops in different cities around the world. The goal was to provide safe and homogeneous training spaces that would be welcoming to people who were not comfortable attending existing opportunities. With training established, GoBridge looked beyond its original mission to see what else it could do to help increase diversity in the Go community.
 
-**What is the role of GB in the Go Developer Network (GDN)?**  
+**What is the role of GB in the Go Developer Network (GDN)?**
+
 GB is acting as the current custodians and stewards of the GDN. This means the payment, administration and management of the systems, communications and community interactions directly related to the GDN will be handled by GB directly.
 
-**How does someone get involved in volunteering with the GDN?**  
+**How does someone get involved in volunteering with the GDN?**
+
 The volunteers are a combination of members of the GB leadership team and active Go community organizers within the GDN with Van Riper as the program director. If you are interested in being involved in GB, please email [support@gobridge.org](mailto:support@gobridge.org). We will happily discuss the programs that need help and work with you to find opportunities to be involved.
 
-**What are the GDN membership requirements for meetups?**  
+**What are the <a href="#user-content-membership-requirements" id="membership-requirements">GDN membership requirements</a>
+ for meetups?**
+
 * Your Meetup must adhere to the Go or GB CoC
 * Your Meetup must primarily focus on topics of relevance to Go developers
-* Your Meetup must hold meetings at least once every 3 months
+* Your Meetup must hold recurring in-person meetings once per month or least twice every 3 months
+  Or
+* If virtual, Your Meetup must hold recurring meetings once per month.
 
-The GDN has an inherent monetary and volunteer cost. To that end, meetups must meet these requirements to be added to the GDN. Meetups in the GDN that no longer meet these requirements are subject to be removed from the GDN. 
+The GDN has an inherent monetary and volunteer cost. To that end, meetups must meet these requirements to be added to the GDN. Meetups in the GDN that no longer meet these requirements are subject to be removed from the GDN.
 
-**What is the process by which groups are removed from the GDN?**  
+**What is the process by which groups are removed from the GDN?**
 * Groups are reviewed quarterly to validate their activity and events.
 * Groups will be contacted if it appears the group is not making an effort to be active.
 * GB will do its very best to help groups that are struggling and need the extra support.
-* Meetup organizers of existing groups may be called in to provide help and assistance. 
+* Meetup organizers of existing groups may be called in to provide help and assistance.
 * Groups that are unable to sustain a membership and activity will be considered for removal.
 * Removal will not occur without discussions with organizers.
 
-**Do organizers lose their autonomy when joining the GDN?**  
-Absolutely not. Joining your Meetup into the GDN just means you become a part of this global network of user groups. By joining, you have direct access to GB volunteers who are helping to administer and support the network. Not every organizer needs the same support, but GB is here to help in any way they can to support the meetup and their local participants. 
+**Do organizers lose their autonomy when joining the GDN?**
 
-**What support can a user group expect to receive when joining the GDN?**  
+Absolutely not. Joining your Meetup into the GDN just means you become a part of this global network of user groups. By joining, you have direct access to GB volunteers who are helping to administer and support the network. Not every organizer needs the same support, but GB is here to help in any way they can to support the meetup and their local participants.
+
+**What support can a user group expect to receive when joining the GDN?**
+
 GB is here to help with things like:
 
 * Handling CoC violations.
@@ -44,13 +62,15 @@ GB is here to help with things like:
 * Support in finding speakers both locally and remote.
 * Special access to swag.
 
-**Can I remove my user group from the GDN?**  
+**Can I remove my user group from the GDN?**
+
 Yes. If you decide you no longer want to be a part of the GDN, just send an email to [gdn@gobridge.org](mailto:gdn@gobridge.org) and let us know.
 
-**Is the GB CoC different from the Go CoC?**  
+**Is the GB CoC different from the Go CoC?**
+
 GB uses the Go CoC as its base document and added three addendums. These addendums were put in place to clarify how the CoC is moderated. We also added the names of those volunteers who are helping to moderate our spaces. We believe the GB CoC is more of a clarifying document and will provide better CoC support for your meetup. That being said, it’s not a requirement to use.
 
 [coc.gobridge.org](http://coc.gobridge.org/)
 
-**Contact Us**  
+**Contact Us**
 If you have any other questions or concerns regarding the GDN not already addressed here, please send an email to [gdn@gobridge.org](mailto:gdn@gobridge.org).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The volunteers are a combination of members of the GB leadership team and active
 * Your Meetup must adhere to the Go or GB CoC
 * Your Meetup must primarily focus on topics of relevance to Go developers
 * Your Meetup must hold recurring in-person meetings once per month or least twice every 3 months
-  Or
 * If virtual, Your Meetup must hold recurring meetings once per month.
 
 The GDN has an inherent monetary and volunteer cost. To that end, meetups must meet these requirements to be added to the GDN. Meetups in the GDN that no longer meet these requirements are subject to be removed from the GDN.

--- a/program_charter.md
+++ b/program_charter.md
@@ -1,0 +1,40 @@
+## Program Charter
+The GDN is a collection of Go user groups working together with a shared mission to empower developer communities with the knowledge, experience, and wisdom to build the next generation of software in Go. This network creates a single place to search for local Gopher groups, workshops, and events.
+
+### Key Initiatives
+---
+### Meetup Pro Services
+The GDN revolves around meetup groups; its main focus is to help bring together existing and new Go user groups for the community to participate in. The GDN (https://www.meetup.com/pro/go/) currently has 102 groups spread across 51 countries, with over 90,000+ members. To bring our Go user groups together, we ask all active groups to join the GDN pro meetup account, where we cover all meetup fees and provide Zoom meeting support.
+
+Our goal is to make it easy for new groups to be discovered within the Go community and provide them with resources to be successful.
+
+#### Tasks include:
+
+* Assist with group registrations to the GDN, which involves adding new members, tracking active meetups for existing members, and managing group membership.
+* Regularly communicate with meetup groups to see how we can help engage their communities; this is important for groups with large memberships but low activity.
+* Build tooling and processes to help survey groups that are doing well or are in need.
+* Maintain the FAQs and relevant content with the GDN GitHub repository https://github.com/gobridge/gdn/
+
+
+### Local Meetup Events
+Once a group is active, it takes work to coordinate speakers, venues, and food for events. The GDN would like to encourage local groups, where possible, to host regular in-person meetups every month. We are shooting for monthly to help keep engagement active, but we are aware that may not always be possible.
+
+Our goal is to have ambassadors work with one or more local groups to help find speakers and venues to host local meetups. Depending on the locality of the ambassador getting details on local sponsorship may require working with the local meetup organizers to establish relationships with local businesses that can help support.
+
+#### Tasks include:
+* Establish a relationship with one or more local meetups that you can assist in setting up events. Work to understand the needs of the local groups.
+* Set up a process where local meetups in need can open an issue to request speakers, venues, or other resources for their upcoming events.
+* Work with the GDN team and our network to find speakers for local groups in need.
+* Help meetup groups set up remote Zoom sessions.
+
+### Local Workshops
+Like the local meetup events, the GDN would like to encourage groups to offer hands-on workshops; at least twice a year if possible. There is a lot of great content in the community on using Go, which sometimes people find hard to practice without some guided help; this is where workshops come in.
+
+Our goal here is to work with community content creators to build up a set of resources for local workshops. This work overlaps with the local meetup events work for finding venues, providing instructors, and budgeting for the workshop.
+
+#### Tasks include:
+* Establish relationships with content creators to help identify what resources that can be made available for free local workshops. Some creators may offer to donate a one-time pass.
+* Set up a process where local meetups can request help when setting up a workshop.
+* Work with the GDN team and local organizers to find relevant content for local workshops. We should follow the process in https://github.com/gobridge/workshops
+
+


### PR DESCRIPTION
The requirements for staying with the GDN have moved from once a quarter to once a month or, at least, twice per quarter. This change was made in effort to keep the Go communities around the world in engaged and vibrant.

Along with the requirements change an initiative document has been added to inform members on what type of help they can expect from the GDN.

